### PR TITLE
fix: consider locks acquired in the future to be stale

### DIFF
--- a/lib/lockfile.js
+++ b/lib/lockfile.js
@@ -82,7 +82,9 @@ function acquireLock(file, options, callback) {
 }
 
 function isLockStale(stat, options) {
-    return stat.mtime.getTime() < Date.now() - options.stale;
+    // On some systems it can happen that the time is rewinded after a hard reboot
+    // This would leave us with a lock that seems to be held at a future time.
+    return Math.abs(Date.now() - stat.mtime.getTime()) > options.stale;
 }
 
 function removeLock(file, options, callback) {

--- a/test/lock.test.js
+++ b/test/lock.test.js
@@ -183,6 +183,19 @@ it('should remove and acquire over stale locks', async () => {
     expect(fs.statSync(`${tmpDir}/foo.lock`).mtime.getTime()).toBeGreaterThan(Date.now() - 3000);
 });
 
+it('should remove and acquire locks from the future', async () => {
+    const mtime = new Date(Date.now() + 60000);
+
+    fs.writeFileSync(`${tmpDir}/foo`, '');
+    fs.mkdirSync(`${tmpDir}/foo.lock`);
+    fs.utimesSync(`${tmpDir}/foo.lock`, mtime, mtime);
+
+    await lockfile.lock(`${tmpDir}/foo`);
+
+    expect(fs.statSync(`${tmpDir}/foo.lock`).mtime.getTime()).toBeGreaterThan(Date.now() - 3000);
+    expect(fs.statSync(`${tmpDir}/foo.lock`).mtime.getTime()).toBeLessThan(Date.now() + 3000);
+});
+
 it('should retry if the lockfile was removed when verifying staleness', async () => {
     const mtime = new Date(Date.now() - 60000);
     let count = 0;


### PR DESCRIPTION
We're sometimes running into a situation where a hard system restart causes the system time to jump backwards. This causes locks to remain with an mtime in the future, unable to lock them.

This PR considers the stale interval in both directions. Any lock that is `stale` milliseconds older or newer than `now()` will be considered stale.